### PR TITLE
Add ESM version

### DIFF
--- a/packages/remotion-animated/bundle.ts
+++ b/packages/remotion-animated/bundle.ts
@@ -1,0 +1,26 @@
+import { build, semver, version } from 'bun';
+
+if (process.env.NODE_ENV !== 'production') {
+  throw new Error('This script must be run using NODE_ENV=production');
+}
+
+if (!semver.satisfies(version, '^1.1.7')) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `There is a bug with bundling when using Bun <1.1.7. You use ${version}. Please use a newer version`
+  );
+  process.exit(1);
+}
+
+const output = await build({
+  entrypoints: ['src/index.tsx'],
+  naming: '[name].mjs',
+  target: 'browser',
+  external: ['remotion', 'react'],
+});
+
+const [file] = output.outputs;
+const text = await file.text();
+await Bun.write('dist/esm/index.mjs', text);
+console.log('Bundled ESM module');
+export {};

--- a/packages/remotion-animated/package.json
+++ b/packages/remotion-animated/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "prepublish": "rm -f ./README.md && cp ../../README.md ./README.md",
-    "build": "tsc -d",
+    "build": "tsc -d && NODE_ENV=production bun bundle.ts",
     "watch": "tsc -w",
     "lint": "eslint *.ts*"
   },
@@ -30,11 +30,13 @@
     "es"
   ],
   "source": "src/index.tsx",
+  "module": "dist/esm/index.mjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "devDependencies": {
     "@types/react": "^18.2.18",
     "@types/react-dom": "^18.2.7",
+    "@types/bun": "^1.1.1",
     "eslint": "^8.46.0",
     "eslint-config-custom": "*",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,6 +2292,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bun@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/bun/-/bun-1.1.1.tgz#f3ec72c7645a267cae5684b14a0d107c9dc96e89"
+  integrity sha512-lUe9rLMhgDCViciZtgDj5CMl2u7uTq/IP149kSZH/Si6FWkCioximABFf+baRQgbm8QlH4bzT0qJRteQFNqeGA==
+  dependencies:
+    bun-types "1.1.6"
+
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
@@ -2412,6 +2419,13 @@
   version "17.0.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
+"@types/node@~20.11.3":
+  version "20.11.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.30.tgz#9c33467fc23167a347e73834f788f4b9f399d66f"
+  integrity sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -2547,6 +2561,13 @@
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
   integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ws@~8.5.10":
+  version "8.5.10"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.10.tgz#4acfb517970853fa6574a3a6886791d04a396787"
+  integrity sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==
   dependencies:
     "@types/node" "*"
 
@@ -3512,6 +3533,14 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+bun-types@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/bun-types/-/bun-types-1.1.6.tgz#6d053b5d580ae3c4dcfc3a4870ceb19fcdc84333"
+  integrity sha512-LK2aaJdBBTUkDyN+kRiJHLF3VGrAcdkEHrbBvbmTkccShPw6ZalxxKjWSBJwn4UkikhZdrdA87bZWmfUgkRUYg==
+  dependencies:
+    "@types/node" "~20.11.3"
+    "@types/ws" "~8.5.10"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -9559,6 +9588,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unherit@^1.0.4:
   version "1.1.3"


### PR DESCRIPTION
It fails when importing this library from an ES Module. Sample bug report:

> Hi everyone, I'm trying to use remotion-animated and I'm getting this error:
"SyntaxError: Cannot use import statement outside a module"
> I tried using both import and require like this but none of them seem to work:
> import { Animated, Move, Scale, Fade, Rotate } from "remotion-animated"
> const { Animated, Move, Scale, Fade, Rotate } = require("remotion-animated")
> In my package.json I'm using  "type": "module"
> Any idea how to fix it?
> btw, remotion is awesome

It can be fixed by adding an ESM version to it!
Btw, for this, Bun needs to be installed, I hope that is okay! It is the fastest bundler out there at the moment.